### PR TITLE
fix: sort git tags

### DIFF
--- a/vars/getDevTag.groovy
+++ b/vars/getDevTag.groovy
@@ -4,7 +4,7 @@ def call(String repoDir = '.') {
   dir(repoDir) {
     sh(returnStdout: true, script: '''
       git fetch origin
-      LATEST_VERSION=$(git tag -l --sort=version:refname | tail -n1)
+      LATEST_VERSION=$(git tag -l | sort -V | tail -n1)
       VERSION_PARTS=(`echo "$LATEST_VERSION" | tr "." "\\n"`)
       NEXT_VERSION=${VERSION_PARTS[0]}.$((${VERSION_PARTS[1]} + 1)).0
       NUM_COMMITS=$(git rev-list HEAD --count)


### PR DESCRIPTION
Probably older version of git used in ci which does not support `--sort=version:refname`. Use `sort -V` instead. [1]

[1] https://mobile-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/blue/organizations/jenkins/mobile-developer-console-operator/detail/master/25/pipeline